### PR TITLE
Solve the 'message too long' problem

### DIFF
--- a/raspbot/.env.example
+++ b/raspbot/.env.example
@@ -18,6 +18,9 @@ POSTGRES_PASSWORD=password  # Database user password
 DB_HOST=localhost  # Database host (name of the service / container)
 DB_PORT=5432  # Database connection port
 
+# Telegram API
+MAX_TG_MSG_LENGTH=4096  # Maximum length of a message allowed by Telegram API
+
 # Timetables
 CLOSEST_DEP_LIMIT=12
 DEP_FORMAT=%H:%M

--- a/raspbot/.env.example
+++ b/raspbot/.env.example
@@ -38,3 +38,6 @@ LOG_DIR=logs  # Directory for keeping the log files
 LOG_FILE=raspbot.log  # Log filename
 LOG_FILE_SIZE=10485760  # Log file size
 LOG_FILES_TO_KEEP=5  # Number of log files to keep in rotation
+
+# Other
+MAX_THREADS_FOR_LONG_FMT=20  # Max amount of timetable threads before the reply message switches to simplified format

--- a/raspbot/bot/constants/messages.py
+++ b/raspbot/bot/constants/messages.py
@@ -121,37 +121,65 @@ class FormattedDifferentThreadList:
     def __init__(self, thread_list: list[ThreadResponse]):
         self.thread_list = thread_list
 
-    def station_to_settlement(self) -> str:
+    @property
+    def different_destination_stations(self) -> str:
         return (
             "⚠️ Обратите внимание, что электрички прибывают на разные станции!\n"
             "В скобках рядом с каждым отправлением указана станция прибытия.\n\n"
-        ) + "\n".join(dep.message_with_destination_station for dep in self.thread_list)
+        )
 
-    def settlement_to_station(self) -> str:
+    @property
+    def different_departure_stations(self) -> str:
         return (
             "⚠️ Обратите внимание, что электрички отправляются с разных станций!\n"
             "В скобках рядом с каждым отправлением указана станция отправления.\n\n"
-        ) + "\n".join(dep.message_with_departure_station for dep in self.thread_list)
+        )
 
-    def settlement_one_to_settlement_diff(self) -> str:
+    @property
+    def same_dep_diff_dest_stations(self) -> str:
         return (
             f"Все электрички отправляются от станции {self.thread_list[0].from_}.\n"
             "⚠️ Однако обратите внимание, что станции прибытия у всех электричек "
             "разные!\nОни указаны в скобках рядом с каждым отправлением.\n\n"
-        ) + "\n".join(dep.message_with_destination_station for dep in self.thread_list)
+        )
 
-    def settlement_diff_to_settlement_one(self) -> str:
+    @property
+    def diff_dep_same_dest_stations(self) -> str:
         return (
             "⚠️ Обратите внимание, что у всех электричек разные станции отправления!\n"
             "Они указаны в скобках рядом с каждым отправлением.\n"
             f"Станция прибытия всех электричек - {self.thread_list[0].to}.\n\n"
-        ) + "\n".join(dep.message_with_departure_station for dep in self.thread_list)
+        )
 
-    def settlement_diff_to_settlement_diff(self) -> str:
+    @property
+    def diff_dep_diff_dest_stations(self) -> str:
         return (
             "⚠️ Обратите внимание, что у всех электричек разные станции отправления "
             "и прибытия!\nОни указаны в скобках рядом с каждым отправлением.\n\n"
-        ) + "\n".join(
+        )
+
+    def station_to_settlement(self) -> str:
+        return self.different_destination_stations + "\n".join(
+            dep.message_with_destination_station for dep in self.thread_list
+        )
+
+    def settlement_to_station(self) -> str:
+        return self.different_departure_stations + "\n".join(
+            dep.message_with_departure_station for dep in self.thread_list
+        )
+
+    def settlement_one_to_settlement_diff(self) -> str:
+        return self.same_dep_diff_dest_stations + "\n".join(
+            dep.message_with_destination_station for dep in self.thread_list
+        )
+
+    def settlement_diff_to_settlement_one(self) -> str:
+        return self.diff_dep_same_dest_stations + "\n".join(
+            dep.message_with_departure_station for dep in self.thread_list
+        )
+
+    def settlement_diff_to_settlement_diff(self) -> str:
+        return self.diff_dep_diff_dest_stations + "\n".join(
             dep.message_with_departure_and_destination for dep in self.thread_list
         )
 

--- a/raspbot/bot/routes/handlers.py
+++ b/raspbot/bot/routes/handlers.py
@@ -179,11 +179,12 @@ async def choose_destination_from_multiple_callback(
     route: RouteResponse = await route_finder.get_or_create_route(
         departure_point=departure_point, destination_point=selected_point, user=user
     )
-    timetable_obj = Timetable(route=route, limit=settings.CLOSEST_DEP_LIMIT)
+    timetable_obj = Timetable(
+        route=route, limit=settings.CLOSEST_DEP_LIMIT, add_msg_text=str(msg_text)
+    )
     logger.debug(f"Creating timetable_obj: {timetable_obj.__dict__}")
     await process_today_timetable_callback(
         callback=callback,
         state=state,
         timetable_obj=timetable_obj,
-        add_msg_text=str(msg_text),
     )

--- a/raspbot/bot/timetable/handlers.py
+++ b/raspbot/bot/timetable/handlers.py
@@ -30,15 +30,16 @@ async def process_today_timetable_callback(
     state: FSMContext,
     timetable_obj: Timetable,
 ):
-    timetable_obj_msg = await timetable_obj.msg
-    logger.debug(f"text: {timetable_obj_msg}")
-    await callback.message.answer(
-        text=timetable_obj_msg,
-        reply_markup=await kb.get_today_departures_keyboard(
-            timetable_obj=timetable_obj
-        ),
-        parse_mode="HTML",
-    )
+    timetable_obj_msgs: tuple = await timetable_obj.msg
+    # logger.debug(f"text: {timetable_obj_msg}")
+    for part in timetable_obj_msgs:
+        await callback.message.answer(
+            text=part,
+            reply_markup=await kb.get_today_departures_keyboard(
+                timetable_obj=timetable_obj
+            ),
+            parse_mode="HTML",
+        )
     await callback.answer()
     await state.update_data(timetable_obj=timetable_obj)
     await state.set_state(states.TimetableState.exact_departure_info)
@@ -49,15 +50,16 @@ async def process_date_timetable_callback(
     state: FSMContext,
     timetable_obj: Timetable,
 ):
-    timetable_obj_msg = await timetable_obj.msg
-    await callback.message.answer(
-        text=timetable_obj_msg,
-        reply_markup=await kb.get_date_departures_keyboard(
-            route_id=timetable_obj.route.id
-        ),
-        parse_mode="HTML",
-    )
-    await callback.answer()
+    timetable_obj_msgs = await timetable_obj.msg
+    for part in timetable_obj_msgs:
+        await callback.message.answer(
+            text=part,
+            reply_markup=await kb.get_date_departures_keyboard(
+                route_id=timetable_obj.route.id
+            ),
+            parse_mode="HTML",
+        )
+        await callback.answer()
     await state.set_state(states.TimetableState.other_date)
 
 

--- a/raspbot/bot/timetable/handlers.py
+++ b/raspbot/bot/timetable/handlers.py
@@ -29,14 +29,11 @@ async def process_today_timetable_callback(
     callback: types.CallbackQuery,
     state: FSMContext,
     timetable_obj: Timetable,
-    add_msg_text: str | None = None,
 ):
     timetable_obj_msg = await timetable_obj.msg
-    logger.debug(
-        "text: " f"{(add_msg_text if add_msg_text else '') + timetable_obj_msg}"
-    )
+    logger.debug(f"text: {timetable_obj_msg}")
     await callback.message.answer(
-        text=((add_msg_text + "\n" * 2) if add_msg_text else "") + timetable_obj_msg,
+        text=timetable_obj_msg,
         reply_markup=await kb.get_today_departures_keyboard(
             timetable_obj=timetable_obj
         ),

--- a/raspbot/db/base.py
+++ b/raspbot/db/base.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Generator
+from typing import AsyncGenerator
 
 from sqlalchemy.ext.asyncio import (
     AsyncAttrs,
@@ -32,7 +32,7 @@ engine = create_async_engine(settings.database_url)
 AsyncSessionLocal = async_sessionmaker(engine, expire_on_commit=False)
 
 
-async def get_session() -> Generator[AsyncSession, None, None]:
+async def get_session() -> AsyncGenerator[AsyncSession, None]:
     async_session = async_sessionmaker(engine, expire_on_commit=False)
     async with async_session() as session:
         yield session

--- a/raspbot/services/split.py
+++ b/raspbot/services/split.py
@@ -1,0 +1,40 @@
+def split_string_list(string_list: list[str], limit: int) -> list[list[str]]:
+    """Split a list of strings into several lists each not exceeding the symbols limit.
+
+    Args:
+        string_list (list[str]): A list of strings that needs splitting.
+        limit (int): A limit that each sub-list shall not exceed.
+
+    Returns:
+        list[list[str]]: A list of sub-lists split as per the limit.
+    """
+    # Initialize an empty list to store the split lists
+    split_lists = []
+
+    # Initialize variables to keep track of the cumulative symbols count and the
+    # current sublist
+    symbols_count = 0
+    current_list = []
+
+    # Iterate over the string list
+    for string in string_list:
+        # Check if adding the current string will exceed the limit
+        if symbols_count + len(string) > limit:
+            # Add the current sublist to the split lists
+            split_lists.append(current_list)
+
+            # Reset the variables for the new sublist
+            symbols_count = 0
+            current_list = []
+
+        # Add the current string to the current sublist
+        current_list.append(string)
+
+        # Update the cumulative symbols count
+        symbols_count += len(string)
+
+    # Add the last sublist to the split lists
+    split_lists.append(current_list)
+
+    # Return the list of lists of strings
+    return split_lists

--- a/raspbot/services/timetable.py
+++ b/raspbot/services/timetable.py
@@ -292,6 +292,13 @@ class Timetable:
         timetable = await self._full_timetable
         return len(timetable)
 
+    async def shorten_msg(self) -> str:
+        """Shortens the message that is too long.
+
+        Returns the shortened message.
+        """
+        pass
+
     @async_property
     async def msg(self) -> str:
         """
@@ -322,10 +329,13 @@ class Timetable:
             if self.limit or length <= settings.INLINE_DEPARTURES_QTY
             else msg.PRESS_DEPARTURE_BUTTON_OR_TYPE
         )
-        return (
+        message = (
             f"{message_part_one.format(route=str(self.route))}\n\n{thread_list}"
             f"\n\n{message_part_two}"
         )
+        if len(message) > settings.MAX_TG_MSG_LENGTH:
+            message = await self.shorten_msg()
+        return message
 
     def unlimit(self) -> Self:
         # TODO: Complete docstring

--- a/raspbot/services/timetable.py
+++ b/raspbot/services/timetable.py
@@ -22,10 +22,12 @@ class Timetable:
         route: Route | RouteResponse,
         date: dt.date = dt.date.today(),
         limit: int | None = None,
+        add_msg_text: str | None = None,
     ):
         self.route = route
         self.date = date
         self.limit = limit
+        self.add_msg_text = add_msg_text
 
     async def _get_timetable_dict(
         self,
@@ -179,10 +181,10 @@ class Timetable:
                 carrier=thread["carrier"]["title"],
                 transport_subtype=thread["transport_subtype"]["title"],
                 express_type=thread["express_type"],
-                from_=short_from_title
-                if short_from_title
-                else segment["from"]["title"],
-                to=short_to_title if short_to_title else segment["to"]["title"],
+                from_=(
+                    short_from_title if short_from_title else segment["from"]["title"]
+                ),
+                to=(short_to_title if short_to_title else segment["to"]["title"]),
                 departure=departure_time if departure_time else departure,
                 arrival=arrival,
                 date=self.date,
@@ -357,7 +359,9 @@ class Timetable:
             if self.limit or length <= settings.INLINE_DEPARTURES_QTY
             else msg.PRESS_DEPARTURE_BUTTON_OR_TYPE
         )
+        add_msg_text = (self.add_msg_text + "\n" * 2) if self.add_msg_text else ""
         pre_thread_msg_length = len(
+            f"{add_msg_text}"
             f"{message_part_one.format(route=str(self.route))}\n\n"
             f"\n\n{message_part_two}"
         )
@@ -368,6 +372,7 @@ class Timetable:
         if isinstance(thread_list, tuple):
             pass
         message = (
+            f"{add_msg_text}"
             f"{message_part_one.format(route=str(self.route))}\n\n{thread_list}"
             f"\n\n{message_part_two}"
         )

--- a/raspbot/settings.py
+++ b/raspbot/settings.py
@@ -56,6 +56,9 @@ class Settings(BaseSettings):
     LOG_FILE_SIZE: int = 10 * 2**20
     LOG_FILES_TO_KEEP: int = 5
 
+    # Other
+    MAX_THREADS_FOR_LONG_FMT: int = 20
+
     @property
     def headers(self) -> dict[str, str | bytes | None]:
         """Get headers for connection to Yandex API."""

--- a/raspbot/settings.py
+++ b/raspbot/settings.py
@@ -34,7 +34,7 @@ class Settings(BaseSettings):
     DB_PORT: str
 
     # Telegram API
-    MAX_TG_MSG_LENGTH: int
+    MAX_TG_MSG_LENGTH: int = 4096
 
     # Timetables
     CLOSEST_DEP_LIMIT: int = 12

--- a/raspbot/settings.py
+++ b/raspbot/settings.py
@@ -33,6 +33,9 @@ class Settings(BaseSettings):
     DB_HOST: str
     DB_PORT: str
 
+    # Telegram API
+    MAX_TG_MSG_LENGTH: int
+
     # Timetables
     CLOSEST_DEP_LIMIT: int = 12
     DEP_FORMAT: str = "%H:%M"


### PR DESCRIPTION
The `msg` method of the Timetable class now splits the output message and returns a tuple of messages instead of a string. If the initial message was OK in terms of its length (less than 4096 symbols as per the Telegram API) then there will be only one element in the returned tuple. If the overall message exceeds the limit, it is split into several elements in a tuple. The handler now answers the messages  (including callback messages) via the loop, iterating through the tuple generated by the `msg` method.