### PR TITLE
Fix: Sending message with departure does now shows the dep info

### DIFF
--- a/raspbot/bot/timetable/handlers.py
+++ b/raspbot/bot/timetable/handlers.py
@@ -25,6 +25,7 @@ router = Router()
 route_retriever = RouteRetriever()
 
 
+# TODO: the two functions below can be merged
 async def process_today_timetable_callback(
     callback: types.CallbackQuery,
     state: FSMContext,
@@ -115,6 +116,7 @@ async def show_dep_info(
     msg_obj = msg.ThreadInfo(thread=dep_info)
     await message.answer(
         text=str(msg_obj),
+        # FIXME: When viewing dep after text message we don't need the keyboard
         reply_markup=await kb.get_separate_departure_keyboard(
             timetable_obj=timetable_obj,
             this_departure=dep_info,
@@ -167,17 +169,12 @@ async def show_till_the_end_of_the_day_callback(
 
 @router.message(states.TimetableState.exact_departure_info)
 async def select_departure_info_by_text(message: types.Message, state: FSMContext):
-    # FIXME: No action when the dep time is typed in.
     """User: types departure time. Bot: here's the departure info.
 
     Args:
         message: user input
         state: the current FSM state
     """
-    logger.debug(
-        "I am in the select_departure_info_by_text, "
-        f"and the message is {message.text}"
-    )
     timetable_obj: Timetable = await get_timetable_object_from_state(state=state)
     timetable = await timetable_obj.timetable
     logger.debug(f"timetable_obj has {len(timetable)} elements.")

--- a/raspbot/bot/timetable/handlers.py
+++ b/raspbot/bot/timetable/handlers.py
@@ -32,7 +32,6 @@ async def process_today_timetable_callback(
 ):
     """Answers the callback based on the provided Timetable object for today."""
     timetable_obj_msgs: tuple = await timetable_obj.msg
-    logger.debug(f"text: {timetable_obj_msgs}")
     for part in timetable_obj_msgs:
         await callback.message.answer(
             text=part,
@@ -61,8 +60,9 @@ async def process_date_timetable_callback(
             ),
             parse_mode="HTML",
         )
-        await callback.answer()
-    await state.set_state(states.TimetableState.other_date)
+    await callback.answer()
+    await state.update_data(timetable_obj=timetable_obj)
+    await state.set_state(states.TimetableState.exact_departure_info)
 
 
 @router.callback_query(clb.GetTimetableCallbackFactory.filter())
@@ -174,6 +174,10 @@ async def select_departure_info_by_text(message: types.Message, state: FSMContex
         message: user input
         state: the current FSM state
     """
+    logger.debug(
+        "I am in the select_departure_info_by_text, "
+        f"and the message is {message.text}"
+    )
     timetable_obj: Timetable = await get_timetable_object_from_state(state=state)
     timetable = await timetable_obj.timetable
     logger.debug(f"timetable_obj has {len(timetable)} elements.")

--- a/raspbot/bot/timetable/keyboards.py
+++ b/raspbot/bot/timetable/keyboards.py
@@ -73,6 +73,7 @@ async def get_separate_departure_keyboard(
     buttons_qty_in_row: int = settings.INLINE_DEPARTURES_QTY,
 ) -> types.InlineKeyboardMarkup:
     """Keyboard with info about a particular departure."""
+    # FIXME: When viewing dep after text message we don't need the keyboard
     markup: types.InlineKeyboardMarkup = await get_today_departures_keyboard(
         timetable_obj=timetable_obj,
         buttons_qty_in_row=buttons_qty_in_row,

--- a/raspbot/main.py
+++ b/raspbot/main.py
@@ -1,6 +1,14 @@
 import asyncio
+import os
+import sys
 
-from raspbot.bot.bot import start_bot
+current_dir = os.path.dirname(os.path.realpath(__file__))
+parent_dir = os.path.abspath(os.path.join(current_dir, os.pardir))
+
+if parent_dir not in sys.path:
+    sys.path.append(parent_dir)
+
+from raspbot.bot.bot import start_bot  # noqa
 
 if __name__ == "__main__":
     asyncio.run(start_bot())

--- a/raspbot/services/timetable.py
+++ b/raspbot/services/timetable.py
@@ -362,24 +362,18 @@ class Timetable:
             thread_list=timetable,
             max_length=settings.MAX_TG_MSG_LENGTH - pre_thread_msg_length,
         )
-        if len(thread_list) > 1:
-            messages = []
-            for i, msg_part in enumerate(thread_list):
-                cont_next_msg = (
-                    f"\n\n{msg.CONT_NEXT_MSG}" if i != len(thread_list) - 1 else ""
-                )
-                messages.append(
-                    f"{add_msg_text}"
-                    f"{message_part_one.format(route=str(self.route))}\n\n{msg_part}"
-                    f"\n\n{message_part_two}{cont_next_msg}"
-                )
-            return tuple(messages)
-        message = (
-            f"{add_msg_text}"
-            f"{message_part_one.format(route=str(self.route))}\n\n{thread_list}"
-            f"\n\n{message_part_two}"
-        )
-        return (message,)
+
+        messages = []
+        for i, msg_part in enumerate(thread_list):
+            cont_next_msg = (
+                f"\n\n{msg.CONT_NEXT_MSG}" if i != len(thread_list) - 1 else ""
+            )
+            messages.append(
+                f"{add_msg_text}"
+                f"{message_part_one.format(route=str(self.route))}\n\n{msg_part}"
+                f"\n\n{message_part_two}{cont_next_msg}"
+            )
+        return tuple(messages)
 
     def unlimit(self) -> Self:
         """Removes the closest departure limit from the timetable object."""


### PR DESCRIPTION
This was achieved by modifying `process_date_timetable_callback` function in `bot.timetable.handlers` so that it does not change the state to `other_date`. I think it breaks selecting the timetable for other dates, but that's a problem of the future me.