### PR TITLE
Fix suburban-only

### DIFF
--- a/raspbot/bot/routes/handlers.py
+++ b/raspbot/bot/routes/handlers.py
@@ -16,7 +16,7 @@ from raspbot.db.models import UserORM
 from raspbot.db.routes.schema import PointResponsePD, RouteResponsePD
 from raspbot.services.routes import PointRetriever, PointSelector, RouteFinder
 from raspbot.services.timetable import Timetable
-from raspbot.services.users import get_user_from_db
+from raspbot.services.users import create_user, get_user_from_db
 from raspbot.settings import settings
 
 logger = configure_logging(name=__name__)
@@ -30,6 +30,9 @@ route_finder = RouteFinder()
 @router.message(Command("search"))
 async def search_command(message: types.Message, state: FSMContext):
     """User: issues /search command. Bot: please input the departure point."""
+    user = await get_user_from_db(telegram_id=message.from_user.id)
+    if not user:
+        user = await create_user(tg_user=message.from_user)
     await message.answer(msg.INPUT_DEPARTURE_POINT)
     await state.set_state(states.RouteState.selecting_departure_point)
 

--- a/raspbot/db/routes/crud.py
+++ b/raspbot/db/routes/crud.py
@@ -64,7 +64,7 @@ class CRUDPoints(CRUDBase):
 
     async def get_point_by_id(self, id: int) -> PointORM:
         """Gets point by ID."""
-        async with self._sessionmaker() as session:
+        async with self._session as session:
             point = await session.execute(
                 select(PointORM)
                 .options(joinedload(PointORM.region))

--- a/raspbot/db/routes/schema.py
+++ b/raspbot/db/routes/schema.py
@@ -16,7 +16,7 @@ class PointResponsePD(BaseModelPD):
     region_title: str
 
 
-class RouteResponsePD(BaseModelPD, RouteStrMixin):
+class RouteResponsePD(RouteStrMixin, BaseModelPD):
     """Pydantic model for routes."""
 
     id: int

--- a/raspbot/db/stations/parse.py
+++ b/raspbot/db/stations/parse.py
@@ -175,9 +175,14 @@ async def _add_points_to_db(
                     "no yandex_code"
                 )
                 continue
-            if station.transport_type != TransportTypes.SUBURBAN.value:
+            if station.transport_type not in (
+                TransportTypes.TRAIN.value,
+                TransportTypes.SUBURBAN.value,
+                "",
+                None,
+            ):
                 logger.info(
-                    f"Skipping non-suburban transport type: {station.transport_type} "
+                    f"Skipping non-train transport type: {station.transport_type} "
                     f"for station {station.title}"
                 )
                 continue

--- a/raspbot/db/users/crud.py
+++ b/raspbot/db/users/crud.py
@@ -59,7 +59,7 @@ class CRUDRecents(CRUDBase):
                 selection = selection.where(RecentORM.favorite == True)  # noqa
             result = await session.execute(
                 selection.order_by(
-                    desc(RecentORM.count), desc(RecentORM.updated_on)
+                    desc(RecentORM.count), desc(RecentORM.updated_at)
                 ).limit(settings.RECENT_FAV_LIST_LENGTH)
             )
             return result.scalars().unique().all()
@@ -75,7 +75,7 @@ class CRUDRecents(CRUDBase):
             return query.scalars().first()
 
     async def update_recent(self, recent_id: RecentORM) -> RecentORM:
-        """Updates recent 'count' and 'updated_on'."""
+        """Updates recent 'count' and 'updated_at'."""
         async with self._session as session:
             stmt = (
                 update(RecentORM)

--- a/raspbot/db/users/models.py
+++ b/raspbot/db/users/models.py
@@ -70,7 +70,7 @@ class RouteStrMixin:
         )
 
 
-class RouteORM(BaseUserRouteORM, RouteStrMixin):
+class RouteORM(RouteStrMixin, BaseUserRouteORM):
     """Route model."""
 
     departure_point_id: Mapped[int] = mapped_column(ForeignKey("points.id"))

--- a/raspbot/services/users.py
+++ b/raspbot/services/users.py
@@ -74,7 +74,7 @@ async def get_user_fav(user: UserORM) -> list[RecentORM] | None:
 async def update_recent(recent_id: int) -> RecentORM:
     """Update recent count and update date."""
     recent = await crud_recents.get_or_none(_id=recent_id)
-    update_date_before = recent.updated_on
+    update_date_before = recent.updated_at
     logger.info(
         "Здесь должна происходить магия обновления даты. До обновления: "
         f"ID пользователя {recent.user_id}, ID маршрута {recent.route_id}"
@@ -83,13 +83,13 @@ async def update_recent(recent_id: int) -> RecentORM:
     )
 
     updated_element = await crud_recents.update_recent(recent_id=recent_id)
-    if updated_element.updated_on == update_date_before:
+    if updated_element.updated_at == update_date_before:
         logger.warning(
             "Обновление даты не получилось: дата по-прежнему "
-            f"{updated_element.updated_on}."
+            f"{updated_element.updated_at}."
         )
     else:
-        logger.info(f"Дата обновлена: новая дата {updated_element.updated_on}")
+        logger.info(f"Дата обновлена: новая дата {updated_element.updated_at}")
     return updated_element
 
 

--- a/raspbot/services/users.py
+++ b/raspbot/services/users.py
@@ -21,7 +21,7 @@ async def get_user_from_db(telegram_id: int) -> UserORM | None:
     Возвращает:
         Объект пользователя (User) или None.
     """
-    user_from_db: UserORM = await crud_users.get_user_by_telegram_id(
+    user_from_db: UserORM | None = await crud_users.get_user_by_telegram_id(
         telegram_id=telegram_id
     )
     if not user_from_db:


### PR DESCRIPTION
Problem: only the suburban points are being recorded in the DB. This is incorrect since all the ‘train’ marked stations will not go to DB which only leaves us with small suburban-only stations.

Solution: instead of 'suburban', another type of station is used: 'train'.